### PR TITLE
Add UTF-8 CI guard, hash-route auth redirect, and developer quickstart

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,5 +25,8 @@ jobs:
           pip install -r backend/requirements.txt
           pip install pytest pytest-asyncio pytest-cov
 
+      - name: Check repository files are UTF-8
+        run: python backend/scripts/check_utf8.py
+
       - name: Run tests
         run: pytest -vv

--- a/README.md
+++ b/README.md
@@ -72,6 +72,42 @@ Dashboards provide experiment tracking, analytics, and decision support.
 
 ---
 
+# Developer Quickstart ⚡
+
+## Local backend setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+pytest -vv
+```
+
+## Frontend setup
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Docker setup (full stack)
+
+```bash
+docker compose up --build
+```
+
+## Common failures and fixes
+
+- **Pytest collection fails with encoding errors**
+  - Run `python backend/scripts/check_utf8.py` to detect non-UTF-8 tracked files.
+- **Auth redirects to a blank/non-matching page**
+  - Ensure navigation uses hash routes such as `#/login`, `#/profile`, `#/dashboard`.
+- **Frontend cannot reach API locally**
+  - Set `VITE_API_URL` in frontend env to your backend host (default backend is `http://localhost:8000`).
+
+---
+
 # System Architecture 🏗️
 
 ## High-Level System Flow

--- a/backend/scripts/check_utf8.py
+++ b/backend/scripts/check_utf8.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Fail if tracked source/test files are not UTF-8 encoded."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Focus on files that commonly impact pytest collection and code reviews.
+CHECK_EXTENSIONS = {
+    ".py",
+    ".pyi",
+    ".md",
+    ".txt",
+    ".yml",
+    ".yaml",
+    ".json",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".tsx",
+    ".ts",
+    ".js",
+    ".jsx",
+    ".css",
+    ".html",
+    ".sql",
+}
+
+SKIP_SEGMENTS = {
+    "frontend/node_modules",
+    ".git",
+}
+
+
+def tracked_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    files: list[Path] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        if any(segment in line for segment in SKIP_SEGMENTS):
+            continue
+        path = Path(line)
+        if path.suffix in CHECK_EXTENSIONS:
+            files.append(path)
+    return files
+
+
+def main() -> int:
+    invalid_files: list[Path] = []
+
+    for path in tracked_files():
+        try:
+            path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            invalid_files.append(path)
+
+    if invalid_files:
+        print("Found non-UTF-8 files:", file=sys.stderr)
+        for invalid in invalid_files:
+            print(f" - {invalid}", file=sys.stderr)
+        return 1
+
+    print("UTF-8 check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -170,7 +170,7 @@ export async function authFetch<T>(
     if (response.status === 401) {
       // Token expired or invalid
       localStorage.removeItem("auth_token");
-      window.location.href = "/login";
+      window.location.hash = "#/login";
       throw new Error("Unauthorized");
     }
     const error = await response.json().catch(() => ({ detail: "Request failed" }));

--- a/frontend/src/pages/InterviewHistory.tsx
+++ b/frontend/src/pages/InterviewHistory.tsx
@@ -97,10 +97,10 @@ export default function InterviewHistory() {
                       <td>Interview #{interview.interview_number}</td>
                       <td>{new Date(interview.created_at).toLocaleDateString()}</td>
                       <td><span className={`status-badge ${className}`}>{label}</span></td>
-                      <td>{interview.score              !== null ? interview.score.toFixed(0)              : "—"}</td>
-                      <td>{interview.technical_score    !== null ? interview.technical_score.toFixed(0)    : "—"}</td>
-                      <td>{interview.communication_score !== null ? interview.communication_score.toFixed(0) : "—"}</td>
-                      <td>{interview.reasoning_score    !== null ? interview.reasoning_score.toFixed(0)    : "—"}</td>
+                      <td>{interview.score              !== null ? interview.score.toFixed(0)              : "-"}</td>
+                      <td>{interview.technical_score    !== null ? interview.technical_score.toFixed(0)    : "-"}</td>
+                      <td>{interview.communication_score !== null ? interview.communication_score.toFixed(0) : "-"}</td>
+                      <td>{interview.reasoning_score    !== null ? interview.reasoning_score.toFixed(0)    : "-"}</td>
                     </tr>
                   );
                 })}
@@ -140,12 +140,12 @@ export default function InterviewHistory() {
                   borderRadius: 8, padding: "0.75rem", color: "#6c5a3d",
                   fontSize: "0.9rem", margin: "1rem 0",
                 }}>
-                  This interview was interrupted before completion — no scores were
+                  This interview was interrupted before completion - no scores were
                   recorded. You can start a new interview from the Mock Interview page.
                 </p>
               )}
 
-              {/* Score bars — completed only */}
+              {/* Score bars - completed only */}
               {selectedInterview.status === "completed" && selectedInterview.score !== null && (
                 <div className="score-breakdown">
                   <h4>Score Breakdown</h4>


### PR DESCRIPTION
## **User description**
### Motivation

- Prevent pytest collection/runtime failures caused by non-UTF-8 files by failing CI early on encoding regressions.  
- Align frontend auth failure navigation with the app's hash-route routing to avoid navigation inconsistencies.  
- Provide a short developer quickstart and common-failure guidance so contributors can run and troubleshoot the project locally.

### Description

- Add a repository UTF-8 validation script at `backend/scripts/check_utf8.py` that scans tracked source/docs/config files and fails on decode errors.  
- Wire the UTF-8 guard into CI by running `python backend/scripts/check_utf8.py` before `pytest` in `.github/workflows/tests.yml`.  
- Change unauthorized redirect behavior in the frontend helper from `window.location.href = "/login"` to `window.location.hash = "#/login"` in `frontend/src/hooks/useAuth.tsx` to match hash-based routing.  
- Normalize a non-UTF-8 placeholder glyph to `"-"` and make small text fixes in `frontend/src/pages/InterviewHistory.tsx`, and add a `Developer Quickstart` and `Common failures and fixes` section to `README.md`.

### Testing

- Ran `python backend/scripts/check_utf8.py`, which passed and reported UTF-8 validation success.  
- Ran `pytest -q tests/test_auth.py tests/test_health.py`, which collected 24 tests with `21` passing and `3` failing, where the failing auth tests returned `422` and appear related to an LLM prewarm requirement (missing `GOOGLE_API_KEY`) rather than the changes in this PR.  
- CI workflow updated to run the UTF-8 check prior to `pytest` so encoding issues will fail fast on CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7883a258c832e827df8579d584297)


___

## **CodeAnt-AI Description**
**Add a UTF-8 CI check, keep auth redirects on hash routes, and document local setup**

### What Changed
- CI now checks tracked source and docs files for UTF-8 before running tests, so encoding problems fail earlier.
- Unauthorized users are redirected to the app’s hash-based login page instead of a mismatched path, avoiding broken sign-in navigation.
- Missing interview scores now display a simple dash instead of a garbled character, and the abandoned-interview message uses plain text.
- The README now includes a short local setup guide and common fixes for encoding, auth redirects, and frontend API access.

### Impact
`✅ Fewer CI failures from encoding issues`
`✅ Reliable login redirects in hash-routed pages`
`✅ Clearer interview history display`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
