### PR TITLE
Fix auth state reset on 401 hash-route redirects

### DIFF
--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -26,6 +26,7 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | null>(null);
 
 const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+const AUTH_UNAUTHORIZED_EVENT = "auth:unauthorized";
 
 interface LoginResponse {
   access_token: string;
@@ -40,6 +41,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return localStorage.getItem("auth_token");
   });
   const [isLoading, setIsLoading] = useState(true);
+  const resetAuthState = useCallback(() => {
+    setToken(null);
+    setUser(null);
+  }, []);
 
   // Fetch user profile on mount if token exists
   useEffect(() => {
@@ -64,15 +69,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           } else {
             // Token invalid, clear it
             localStorage.removeItem("auth_token");
+            resetAuthState();
           }
         } catch {
           localStorage.removeItem("auth_token");
+          resetAuthState();
         }
       }
       setIsLoading(false);
     };
     void initAuth();
-  }, []);
+  }, [resetAuthState]);
 
   const login = useCallback(async (email: string, password: string) => {
     const formData = new URLSearchParams();
@@ -119,9 +126,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(() => {
     localStorage.removeItem("auth_token");
-    setToken(null);
-    setUser(null);
-  }, []);
+    resetAuthState();
+  }, [resetAuthState]);
+
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      resetAuthState();
+    };
+
+    window.addEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized);
+    return () => {
+      window.removeEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized);
+    };
+  }, [resetAuthState]);
 
   return (
     <AuthContext.Provider
@@ -170,6 +187,7 @@ export async function authFetch<T>(
     if (response.status === 401) {
       // Token expired or invalid
       localStorage.removeItem("auth_token");
+      window.dispatchEvent(new CustomEvent(AUTH_UNAUTHORIZED_EVENT));
       window.location.hash = "#/login";
       throw new Error("Unauthorized");
     }
@@ -179,4 +197,3 @@ export async function authFetch<T>(
 
   return response.json();
 }
-


### PR DESCRIPTION
## **User description**
### Motivation
- Prevent a regression where switching unauthorized navigation to a hash route (`#/login`) only removed `localStorage` but left `AuthProvider`'s in-memory `token`/`user` set, allowing the app to remain in authenticated branches until a full reload.  
- Ensure a single, consistent mechanism clears React auth state across startup token validation failures, logout, and fetch-time 401s so UI and routing remain synchronized.

### Description
- Added an `AUTH_UNAUTHORIZED_EVENT` constant and a `resetAuthState` `useCallback` in `frontend/src/hooks/useAuth.tsx` to centralize clearing `token` and `user` in React state.  
- Call `resetAuthState()` during initial token bootstrap failures (`/api/auth/me`) so expired/invalid stored tokens cannot leave in-memory state behind.  
- Reused `resetAuthState()` from `logout` and installed a window event listener in `AuthProvider` to respond to unauthorized events.  
- Dispatch the unauthorized event from `authFetch` on `401` before setting `window.location.hash = "#/login"` so state is cleared before hash-route navigation occurs.

### Testing
- Ran `cd frontend && npm run lint`, which failed due to pre-existing lint issues in unrelated files (errors reported in `App.tsx`, `VRMAvatar.tsx`, `InterviewPage.tsx`, and existing react-refresh rules).  
- Ran `cd frontend && npm run build`, which failed in this environment because the PostCSS config requires `@tailwindcss/postcss`, a dependency not present here.  
- Verified the updated `frontend/src/hooks/useAuth.tsx` behavior by static inspection to ensure the unauthorized event is dispatched and the provider clears in-memory auth state before hash-route redirect.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c78c125870832e9587d005290c7942)


___

## **CodeAnt-AI Description**
Fix sign-out and login redirects so the app clears authenticated state right away

### What Changed
- When a session is rejected, the app now clears both saved login data and the current in-app user state before sending people to the login page
- Logout now uses the same full reset, so the screen no longer stays signed in after signing out
- Invalid saved tokens are also cleared during startup if the app cannot confirm the session

### Impact
`✅ No stale signed-in screens after 401 errors`
`✅ Reliable logout across hash-route redirects`
`✅ Fewer cases where expired sessions keep showing protected content`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
