### PR TITLE
Fix auth state reset on unauthorized hash redirect

### DIFF
--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -26,6 +26,7 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | null>(null);
 
 const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+const AUTH_UNAUTHORIZED_EVENT = "auth:unauthorized";
 
 interface LoginResponse {
   access_token: string;
@@ -40,6 +41,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return localStorage.getItem("auth_token");
   });
   const [isLoading, setIsLoading] = useState(true);
+  const resetAuthState = useCallback(() => {
+    setToken(null);
+    setUser(null);
+  }, []);
 
   // Fetch user profile on mount if token exists
   useEffect(() => {
@@ -64,15 +69,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           } else {
             // Token invalid, clear it
             localStorage.removeItem("auth_token");
+            resetAuthState();
           }
         } catch {
           localStorage.removeItem("auth_token");
+          resetAuthState();
         }
       }
       setIsLoading(false);
     };
     void initAuth();
-  }, []);
+  }, [resetAuthState]);
 
   const login = useCallback(async (email: string, password: string) => {
     const formData = new URLSearchParams();
@@ -119,9 +126,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(() => {
     localStorage.removeItem("auth_token");
-    setToken(null);
-    setUser(null);
-  }, []);
+    resetAuthState();
+  }, [resetAuthState]);
+
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      resetAuthState();
+    };
+
+    window.addEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized);
+    return () => {
+      window.removeEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized);
+    };
+  }, [resetAuthState]);
 
   return (
     <AuthContext.Provider
@@ -170,6 +187,7 @@ export async function authFetch<T>(
     if (response.status === 401) {
       // Token expired or invalid
       localStorage.removeItem("auth_token");
+      window.dispatchEvent(new CustomEvent(AUTH_UNAUTHORIZED_EVENT));
       window.location.hash = "#/login";
       throw new Error("Unauthorized");
     }
@@ -179,4 +197,3 @@ export async function authFetch<T>(
 
   return response.json();
 }
-


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Keep the signed-in state cleared after unauthorized redirects**

### What Changed
- When a request gets a 401, the app now clears the current user and token before sending the user to the login page
- If a saved token is no longer valid when the app starts, the signed-in state is cleared instead of leaving stale user details on screen
- Logging out uses the same auth reset path, so the login state is removed consistently

### Impact
`✅ Fewer stale login states after session expiry`
`✅ Clearer sign-out behavior after unauthorized access`
`✅ Fewer cases where the app shows a signed-in user after redirecting to login`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
