### PR TITLE
Enable `ping` in all phases and add `DISABLE_TTS` to avoid TTS blocking in WS tests

### DIFF
--- a/backend/models/interview.py
+++ b/backend/models/interview.py
@@ -23,6 +23,9 @@ class InterviewPhase(Enum):
 
     def can_receive(self, message_type: str) -> bool:
         """Check if current phase can receive this message type."""
+        if message_type == "ping":
+            return True
+
         transitions = {
             InterviewPhase.WAITING_RESUME: {"resume_upload"},
             InterviewPhase.PROCESSING_RESUME: set(),

--- a/backend/sockets/interview_gateway.py
+++ b/backend/sockets/interview_gateway.py
@@ -468,6 +468,9 @@ class InterviewGateway:
         return "unknown"
 
     def _synthesize_tts_chunks(self, text: str) -> list:
+        if os.getenv("DISABLE_TTS", "false").lower() == "true":
+            return []
+
         chunks = []
         for segment in self._split_sentences(text):
             audio_bytes, visemes = synthesize_speech_with_visemes(segment)

--- a/tests/test_websocket_interview.py
+++ b/tests/test_websocket_interview.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm import Session, sessionmaker
 os.environ.setdefault("DATABASE_URL", "sqlite:///./test_ws_interview.db")
 os.environ.setdefault("JWT_SECRET_KEY", "test-ws-secret-key")
 os.environ.setdefault("DISABLE_STT", "true")          # no Whisper in CI
+os.environ.setdefault("DISABLE_TTS", "true")          # avoid network TTS in CI
 os.environ.setdefault("GOOGLE_API_KEY", "FAKE_KEY")   # no Gemini calls in CI
 os.environ.setdefault("MAX_CONCURRENT_SESSIONS", "5")
 os.environ.setdefault("RATE_LIMIT_WS_PER_MINUTE", "30")


### PR DESCRIPTION
## **User description**
### Motivation
- The WebSocket greeting test could stall because external TTS synthesis may block and `ping` messages were not accepted in `WAITING_RESUME`, preventing the test's liveness check from receiving `pong`.
- Make the greeting + ping/pong flow deterministic in CI and local runs without relying on network TTS.

### Description
- Allow `ping` messages from any phase by updating `InterviewPhase.can_receive` to return `True` for message type `"ping"` (`backend/models/interview.py`).
- Add an environment-driven short-circuit in the gateway TTS chunk builder so TTS can be disabled via `DISABLE_TTS=true` by returning no TTS chunks from `_synthesize_tts_chunks` (`backend/sockets/interview_gateway.py`).
- Enable `DISABLE_TTS` in the WebSocket test module setup so tests avoid external/network TTS during execution (`tests/test_websocket_interview.py`).

### Testing
- Ran `pytest -vv tests/test_websocket_interview.py::TestWebSocketGreeting::test_greeting_is_followed_by_waiting_state` and the test passed (previously could hang). 
- Ran the full WebSocket test module with `pytest -q tests/test_websocket_interview.py` which progressed past the earlier hang but surfaced two unrelated failing persistence tests: `TestInterviewPersistenceUnit::test_complete_mock_interview_writes_scores` (failed) and `TestInterviewPersistenceUnit::test_fail_mock_interview_marks_abandoned` (failed). Other WebSocket tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c78b387e7c832e9b1cc5b673464eea)


___

## **CodeAnt-AI Description**
**Prevent WebSocket greeting tests from stalling**

### What Changed
- `ping` messages are now accepted in every interview phase, so liveness checks can still get a response during the greeting flow
- WebSocket tests disable text-to-speech by default, avoiding external audio calls that could block test progress
- If text-to-speech is disabled, no speech chunks are generated for outgoing messages

### Impact
`✅ Fewer WebSocket greeting stalls`
`✅ More reliable ping/pong checks`
`✅ Fewer CI hangs from external speech calls`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
